### PR TITLE
Add PHP script to create activity_marks table

### DIFF
--- a/create_activity_marks_table.php
+++ b/create_activity_marks_table.php
@@ -1,0 +1,21 @@
+<?php
+require_once 'db_connect.php';
+
+// SQL to create table
+$sql = "CREATE TABLE activity_marks (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT,
+    activity_number INT,
+    marks INT,
+    `timestamp` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+)";
+
+if ($conn->query($sql) === TRUE) {
+    echo "Table activity_marks created successfully";
+} else {
+    echo "Error creating table: " . $conn->error;
+}
+
+$conn->close();
+?>


### PR DESCRIPTION
This commit introduces a new PHP script, `create_activity_marks_table.php`. This script connects to the MySQL database and creates a new table named `activity_marks`.

The `activity_marks` table has the following schema:
- `id`: INT, PRIMARY KEY, AUTO_INCREMENT
- `user_id`: INT, FOREIGN KEY (references `users(id)`)
- `activity_number`: INT
- `marks`: INT
- `timestamp`: TIMESTAMP, DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP

The script includes basic error handling and will output a success or failure message upon execution. I've also provided instructions on how to run this script.